### PR TITLE
wasm32 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "parking_lot",
  "stdweb",
  "thiserror",
+ "wasm-bindgen",
  "web-sys",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +326,7 @@ dependencies = [
  "nix",
  "oboe",
  "parking_lot",
- "stdweb",
+ "stdweb 0.1.3",
  "thiserror",
  "wasm-bindgen",
  "web-sys",
@@ -488,6 +494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +552,19 @@ checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "stdweb 0.4.20",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -841,6 +866,9 @@ name = "nanorand"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3173d7bb904c5a3a2f9167eb936916a39e97124846b8316223323aed9a34d1e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "ndk"
@@ -1317,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1384,55 @@ name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -1422,7 +1505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1573,6 +1656,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## `wasm32` support
+
+Kira now runs on any platform supporting `wasm32` and having a
+`cpal` backend. This means one can now run an instance of Kira
+in a web browser.
+
 # v0.3.0
 
 ## Per-sequence custom event types

--- a/kira/Cargo.toml
+++ b/kira/Cargo.toml
@@ -27,5 +27,10 @@ indexmap = "1.6.0"
 hound = { version = "3.4.0", optional = true }
 lewton = { version = "0.10.1", optional = true }
 minimp3 = { version = "0.5.0", optional = true }
-nanorand = "0.5.1"
 ringbuf = "0.2.2"
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+nanorand = "0.5.1"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+nanorand = { version = "0.5.1", features = ["getrandom"] }

--- a/kira/Cargo.toml
+++ b/kira/Cargo.toml
@@ -22,7 +22,7 @@ default = ["mp3", "ogg", "flac", "wav"]
 
 [dependencies]
 claxon = { version = "0.4.3", optional = true }
-cpal = "0.13.1"
+cpal = { version = "0.13.1", features = ["wasm-bindgen"] }
 indexmap = "1.6.0"
 hound = { version = "3.4.0", optional = true }
 lewton = { version = "0.10.1", optional = true }

--- a/kira/src/manager/mod.rs
+++ b/kira/src/manager/mod.rs
@@ -131,6 +131,7 @@ impl AudioManager {
 		let (audio_manager_thread_channels, backend_thread_channels, mut quit_signal_consumer) =
 			Self::create_thread_channels(&settings);
 
+		#[cfg(not(target_arch = "wasm32"))]
 		let stream = {
 			let (mut setup_result_producer, mut setup_result_consumer) =
 				RingBuffer::<AudioResult<()>>::new(1).split();
@@ -165,6 +166,9 @@ impl AudioManager {
 
 			None
 		};
+
+		#[cfg(target_arch = "wasm32")]
+		let stream = Some(Self::setup_stream(settings, backend_thread_channels)?);
 
 		Ok(Self {
 			thread_channels: audio_manager_thread_channels,

--- a/kira/src/manager/mod.rs
+++ b/kira/src/manager/mod.rs
@@ -2,7 +2,7 @@
 
 mod backend;
 
-use std::{hash::Hash, path::Path};
+use std::hash::Hash;
 
 #[cfg(not(feature = "benchmarking"))]
 use backend::Backend;
@@ -29,7 +29,7 @@ use crate::{
 		SubTrackId, Track, TrackIndex, TrackSettings,
 	},
 	parameter::{ParameterId, Tween},
-	playable::{Playable, PlayableSettings},
+	playable::Playable,
 	sequence::SequenceInstance,
 	sequence::{EventReceiver, Sequence, SequenceInstanceId, SequenceInstanceSettings},
 	sound::{Sound, SoundId},
@@ -295,10 +295,11 @@ impl AudioManager {
 	///
 	/// This is a shortcut for constructing the sound manually and adding it
 	/// using [`AudioManager::add_sound`].
-	pub fn load_sound<P: AsRef<Path>>(
+	#[cfg(any(feature = "mp3", feature = "ogg", feature = "flac", feature = "wav"))]
+	pub fn load_sound<P: AsRef<std::path::Path>>(
 		&mut self,
 		path: P,
-		settings: PlayableSettings,
+		settings: crate::playable::PlayableSettings,
 	) -> AudioResult<SoundId> {
 		let sound = Sound::from_file(path, settings)?;
 		self.add_sound(sound)

--- a/kira/src/sound/mod.rs
+++ b/kira/src/sound/mod.rs
@@ -16,9 +16,10 @@ use crate::{
 #[cfg(any(feature = "mp3", feature = "ogg", feature = "flac", feature = "wav"))]
 use crate::{error::AudioError, error::AudioResult};
 
+use std::fmt::{Debug, Formatter};
+
 #[cfg(any(feature = "mp3", feature = "ogg", feature = "flac", feature = "wav"))]
 use std::{
-	fmt::{Debug, Formatter},
 	fs::File,
 	path::Path,
 };


### PR DESCRIPTION
File loading does not work and is kind of out of the scope for now I think, audio data should be loaded as frames (the best way to do this is download the audio data using fetch, decode it using WebAudio and play).

This is blocked by aspenluxxxy/nanorand-rs#19. [NO LONGER THE CASE, see below]

Demo: https://first-kira-web-demo.surge.sh/
(wasm file and audio data loading start when clicking on play)