### PR TITLE
Add ending frame position to static_sound

### DIFF
--- a/crates/kira/src/sound/static_sound/settings.rs
+++ b/crates/kira/src/sound/static_sound/settings.rs
@@ -8,6 +8,10 @@ pub struct StaticSoundSettings {
 	pub start_time: StartTime,
 	/// The initial playback position of the sound (in seconds).
 	pub start_position: f64,
+	/// The ending position of the sound (in seconds).
+	///
+	/// If None, play until the end of the sound
+	pub end_position: Option<f64>,
 	/// The volume of the sound.
 	pub volume: Volume,
 	/// The playback rate of the sound.
@@ -37,6 +41,7 @@ impl StaticSoundSettings {
 		Self {
 			start_time: StartTime::default(),
 			start_position: 0.0,
+			end_position: None,
 			volume: Volume::Amplitude(1.0),
 			playback_rate: PlaybackRate::Factor(1.0),
 			panning: 0.5,

--- a/crates/kira/src/sound/static_sound/sound.rs
+++ b/crates/kira/src/sound/static_sound/sound.rs
@@ -47,7 +47,6 @@ impl StaticSound {
 		let settings = data.settings;
 		let starting_frame_index = starting_frame_index(settings, &data);
 		let ending_frame_index = ending_frame_index(settings, &data);
-		println!("starting: {:?}, ending frame index: {:?}", starting_frame_index, ending_frame_index);
 		let position = starting_frame_index as f64 / data.sample_rate as f64;
 		let mut sound = Self {
 			command_consumer,

--- a/crates/kira/src/sound/static_sound/sound.rs
+++ b/crates/kira/src/sound/static_sound/sound.rs
@@ -47,6 +47,7 @@ impl StaticSound {
 		let settings = data.settings;
 		let starting_frame_index = starting_frame_index(settings, &data);
 		let ending_frame_index = ending_frame_index(settings, &data);
+		info!("starting: {:?}, ending frame index: {:?}", starting_frame_index, ending_frame_index);
 		let position = starting_frame_index as f64 / data.sample_rate as f64;
 		let mut sound = Self {
 			command_consumer,


### PR DESCRIPTION
Here is my use case: https://github.com/tesselode/kira/issues/39
I'd like to have a single sound file and then arbitrary portions of them

I tried to make it such that start_position is inclusive and end_position is exclusive:
if you define, start = 0.0, end = 1.0 then the frames will be [start, end[  (the frame corresponding to time 1.0 is end + 1)