### PR TITLE
Add a #cfg to disable the logic that polls for device changes on macOS

### DIFF
--- a/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
@@ -96,6 +96,10 @@ impl StreamManager {
 				}
 			}
 			// check for device changes
+			// Disabled on macos due to audio artifacts that seem to occur when the device is
+			// queried while playing.
+			// see: https://github.com/tesselode/kira/issues/38
+			#[cfg(not(target_os = "macos"))]
 			if let Ok((device, config)) = default_device_and_config() {
 				let device_name = device_name(&device);
 				let sample_rate = config.sample_rate.0;


### PR DESCRIPTION
On macOS this polling causes crackling in the audio. This is most likely due to a bug in the cpal implementation. See: https://github.com/tesselode/kira/issues/38.

This is one of two optional solutions. The other is: #45.

I prefer this one as I don't think this needs to be configurable on macOS.
Preventing this polling seems to eliminate the crackle and I haven't personally found any negative side effects.

Even when switching the default output device between my laptop speakers and a bluetooth speaker this seems to work flawlessly without this manual following of device configuration.