### PR TITLE
Expose feature for shared stdxx on android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+.idea/

--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -34,6 +34,7 @@ mp3 = ["symphonia", "symphonia/mp3"]
 ogg = ["symphonia", "symphonia/ogg", "symphonia/vorbis"]
 flac = ["symphonia", "symphonia/flac"]
 wav = ["symphonia", "symphonia/wav", "symphonia/pcm"]
+android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 
 [dev-dependencies]
 approx = "0.5.1"


### PR DESCRIPTION
The cpal feature seems to be needed to get bevy + kira to work on my android phone.