### PR TITLE
Fix compilation on android

### DIFF
--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -28,6 +28,10 @@ version = "0.15.1"
 optional = true
 features = ["wasm-bindgen"]
 
+[target.'cfg(target_os = "android")'.dependencies.cpal]
+version = "0.15.1"
+features = ["oboe-shared-stdcxx"]
+
 [features]
 default = ["cpal", "mp3", "ogg", "flac", "wav"]
 mp3 = ["symphonia", "symphonia/mp3"]


### PR DESCRIPTION
I have managed to launch audio with kira on ios, but on android I got compilation issue:

<img width="465" alt="Screenshot 2023-07-14 at 17 44 43" src="https://github.com/tesselode/kira/assets/109857267/62073a9d-226c-42e3-9248-f30d9121f087">

I figured out that error was caused by [oboe crate](https://github.com/katyo/oboe-rs) from cpal deps, which requires `shared-stdcxx` feature enabled on android build. With this changes kira works on android perfectly :)