### PR TITLE
update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install cpal dependencies
         run: sudo apt-get install libasound2-dev
       - name: install wasm32 target

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install cpal dependencies
         run: sudo apt-get install libasound2-dev
       - name: run tests (desktop - all features)


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.5.3
> - Fix: Checkout fail in self-hosted runners when faulty submodule are checked-in
> - Fix typos found by codespell
> - Add support for sparse checkouts
>
> ## v3.5.2
> - Fix api endpoint for GHES
>
> ## v3.5.1
> - Fix slow checkout on Windows
>
> ## v3.5.0
> - Add new public key for known_hosts
>
> ## v3.4.0
> - Upgrade codeql actions to v2
> - Upgrade dependencies
> - Upgrade @actions/io
>
> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16


Still using the outdated actions can generate warnings in CI runs, for example in https://github.com/tesselode/kira/actions/runs/5316127649:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.