### PR TITLE
update dependency criterion in benchmark to 0.5.1

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 kira = { path = "../kira" }
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.5.1"
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
The currently used version 0.3.5 of [`criterion`](https://github.com/bheisler/criterion.rs) was released two years ago, so it's probably a good time to update to a more recent version.