### PR TITLE
Add a setting to change the cpal output device

### DIFF
--- a/crates/kira/src/manager/backend/cpal.rs
+++ b/crates/kira/src/manager/backend/cpal.rs
@@ -8,9 +8,9 @@ pub use error::*;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 #[cfg(target_arch = "wasm32")]
-pub use wasm::CpalBackend;
+pub use wasm::{CpalBackend, CpalBackendSettings};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod desktop;
 #[cfg(not(target_arch = "wasm32"))]
-pub use desktop::CpalBackend;
+pub use desktop::{CpalBackend, CpalBackendSettings};

--- a/crates/kira/src/manager/backend/cpal.rs
+++ b/crates/kira/src/manager/backend/cpal.rs
@@ -5,12 +5,20 @@
 mod error;
 pub use error::*;
 
+/// Settings for the [`cpal`] backend.
+#[derive(Default)]
+pub struct CpalBackendSettings {
+	/// The output audio device to use. If [`None`], the default output
+	/// device will be used.
+	pub device: Option<cpal::Device>,
+}
+
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 #[cfg(target_arch = "wasm32")]
-pub use wasm::{CpalBackend, CpalBackendSettings};
+pub use wasm::CpalBackend;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod desktop;
 #[cfg(not(target_arch = "wasm32"))]
-pub use desktop::{CpalBackend, CpalBackendSettings};
+pub use desktop::CpalBackend;

--- a/crates/kira/src/manager/backend/cpal.rs
+++ b/crates/kira/src/manager/backend/cpal.rs
@@ -3,14 +3,30 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "cpal")))]
 
 mod error;
+use cpal::{BufferSize, Device};
 pub use error::*;
 
 /// Settings for the [`cpal`] backend.
-#[derive(Default)]
 pub struct CpalBackendSettings {
 	/// The output audio device to use. If [`None`], the default output
 	/// device will be used.
-	pub device: Option<cpal::Device>,
+	pub device: Option<Device>,
+	/// The buffer size used by the device. If it is set to [`BufferSize::Default`],
+	/// the default buffer size for the device will be used. Note that the default
+	/// buffer size might be surprisingly large, leading to latency issues. If
+	/// a lower latency is desired, consider using [`BufferSize::Fixed`] in accordance
+	/// with the [`cpal::SupportedBufferSize`] range provided by the [`cpal::SupportedStreamConfig`]
+	/// API.
+	pub buffer_size: BufferSize,
+}
+
+impl Default for CpalBackendSettings {
+	fn default() -> Self {
+		Self {
+			device: None,
+			buffer_size: BufferSize::Default,
+		}
+	}
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/kira/src/manager/backend/cpal/desktop.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop.rs
@@ -8,7 +8,7 @@ use cpal::{
 	Device, StreamConfig,
 };
 
-use super::Error;
+use super::{CpalBackendSettings, Error};
 
 enum State {
 	Empty,
@@ -19,14 +19,6 @@ enum State {
 	Initialized {
 		stream_manager_controller: StreamManagerController,
 	},
-}
-
-/// Settings for the [`cpal`] backend.
-#[derive(Default)]
-pub struct CpalBackendSettings {
-	/// The output audio device to use. If [`None`], the default output
-	/// device will be used.
-	pub device: Option<Device>,
 }
 
 /// A backend that uses [cpal](https://crates.io/crates/cpal) to

--- a/crates/kira/src/manager/backend/cpal/desktop.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop.rs
@@ -5,7 +5,7 @@ use stream_manager::{StreamManager, StreamManagerController};
 use crate::manager::backend::{Backend, Renderer};
 use cpal::{
 	traits::{DeviceTrait, HostTrait},
-	Device, StreamConfig,
+	BufferSize, Device, StreamConfig,
 };
 
 use super::{CpalBackendSettings, Error};
@@ -27,6 +27,7 @@ pub struct CpalBackend {
 	state: State,
 	/// Whether the device was specified by the user.
 	custom_device: bool,
+	buffer_size: BufferSize,
 }
 
 impl Backend for CpalBackend {
@@ -53,6 +54,7 @@ impl Backend for CpalBackend {
 			Self {
 				state: State::Uninitialized { device, config },
 				custom_device,
+				buffer_size: settings.buffer_size,
 			},
 			sample_rate,
 		))
@@ -67,6 +69,7 @@ impl Backend for CpalBackend {
 					device,
 					config,
 					self.custom_device,
+					self.buffer_size,
 				),
 			};
 		} else {

--- a/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::manager::backend::Renderer;
 use cpal::{
 	traits::{DeviceTrait, HostTrait, StreamTrait},
-	Device, Stream, StreamConfig, StreamError,
+	BufferSize, Device, Stream, StreamConfig, StreamError,
 };
 use ringbuf::{HeapConsumer, HeapRb};
 
@@ -51,14 +51,16 @@ pub(super) struct StreamManager {
 	device_name: String,
 	sample_rate: u32,
 	custom_device: bool,
+	buffer_size: BufferSize,
 }
 
 impl StreamManager {
 	pub fn start(
 		renderer: Renderer,
 		device: Device,
-		config: StreamConfig,
+		mut config: StreamConfig,
 		custom_device: bool,
+		buffer_size: BufferSize,
 	) -> StreamManagerController {
 		let should_drop = Arc::new(AtomicBool::new(false));
 		let should_drop_clone = should_drop.clone();
@@ -68,8 +70,9 @@ impl StreamManager {
 				device_name: device_name(&device),
 				sample_rate: config.sample_rate.0,
 				custom_device,
+				buffer_size,
 			};
-			stream_manager.start_stream(&device, &config).unwrap();
+			stream_manager.start_stream(&device, &mut config).unwrap();
 			loop {
 				std::thread::sleep(CHECK_STREAM_INTERVAL);
 				if should_drop.load(Ordering::SeqCst) {
@@ -93,9 +96,9 @@ impl StreamManager {
 			// check for device disconnection
 			if let Some(StreamError::DeviceNotAvailable) = stream_error_consumer.pop() {
 				self.stop_stream();
-				if let Ok((device, config)) = default_device_and_config() {
+				if let Ok((device, mut config)) = default_device_and_config() {
 					// TODO: gracefully handle errors that occur in this function
-					self.start_stream(&device, &config).unwrap();
+					self.start_stream(&device, &mut config).unwrap();
 				}
 			}
 			// check for device changes if a custom device hasn't been specified
@@ -104,25 +107,26 @@ impl StreamManager {
 			// see: https://github.com/tesselode/kira/issues/38
 			#[cfg(not(target_os = "macos"))]
 			if !self.custom_device {
-				if let Ok((device, config)) = default_device_and_config() {
+				if let Ok((device, mut config)) = default_device_and_config() {
 					let device_name = device_name(&device);
 					let sample_rate = config.sample_rate.0;
 					if device_name != self.device_name || sample_rate != self.sample_rate {
 						self.stop_stream();
-						self.start_stream(&device, &config).unwrap();
+						self.start_stream(&device, &mut config).unwrap();
 					}
 				}
 			}
 		}
 	}
 
-	fn start_stream(&mut self, device: &Device, config: &StreamConfig) -> Result<(), Error> {
+	fn start_stream(&mut self, device: &Device, config: &mut StreamConfig) -> Result<(), Error> {
 		let mut renderer =
 			if let State::Idle { renderer } = std::mem::replace(&mut self.state, State::Empty) {
 				renderer
 			} else {
 				panic!("trying to start a stream when the stream manager is not idle");
 			};
+		config.buffer_size = self.buffer_size; // this won't change anything if the buffer size is BufferSize::Default
 		let device_name = device_name(device);
 		let sample_rate = config.sample_rate.0;
 		if sample_rate != self.sample_rate {

--- a/crates/kira/src/manager/backend/cpal/wasm.rs
+++ b/crates/kira/src/manager/backend/cpal/wasm.rs
@@ -4,7 +4,7 @@ use cpal::{
 	Device, Stream, StreamConfig,
 };
 
-use super::Error;
+use super::{CpalBackendSettings, Error};
 
 enum State {
 	Empty,
@@ -15,13 +15,6 @@ enum State {
 	Initialized {
 		_stream: Stream,
 	},
-}
-
-/// Settings for the [`cpal`] backend.
-pub struct CpalBackendSettings {
-	/// The output audio device to use. If [`None`], the default output
-	/// device will be used.
-	pub device: Option<Device>,
 }
 
 /// A backend that uses [cpal](https://crates.io/crates/cpal) to

--- a/crates/kira/src/manager/backend/cpal/wasm.rs
+++ b/crates/kira/src/manager/backend/cpal/wasm.rs
@@ -17,6 +17,13 @@ enum State {
 	},
 }
 
+/// Settings for the [`cpal`] backend.
+pub struct CpalBackendSettings {
+	/// The output audio device to use. If [`None`], the default output
+	/// device will be used.
+	pub device: Option<Device>,
+}
+
 /// A backend that uses [cpal](https://crates.io/crates/cpal) to
 /// connect a [`Renderer`] to the operating system's audio driver.
 pub struct CpalBackend {
@@ -24,15 +31,18 @@ pub struct CpalBackend {
 }
 
 impl Backend for CpalBackend {
-	type Settings = ();
+	type Settings = CpalBackendSettings;
 
 	type Error = Error;
 
 	fn setup(_settings: Self::Settings) -> Result<(Self, u32), Self::Error> {
 		let host = cpal::default_host();
-		let device = host
-			.default_output_device()
-			.ok_or(Error::NoDefaultOutputDevice)?;
+		let device = if let Some(device) = settings.device {
+			device
+		} else {
+			host.default_output_device()
+				.ok_or(Error::NoDefaultOutputDevice)?
+		};
 		let config = device.default_output_config()?.config();
 		let sample_rate = config.sample_rate.0;
 		Ok((


### PR DESCRIPTION
This adds a cpal backend settings type which has a `device` field. If it is Some, then the specified output audio device will be used. Otherwise the default device is used (https://github.com/tesselode/kira/issues/63).