### PR TITLE
allow streaming sounds of unknown length

### DIFF
--- a/crates/kira/src/sound/static_sound/sound.rs
+++ b/crates/kira/src/sound/static_sound/sound.rs
@@ -52,7 +52,7 @@ impl StaticSound {
 			data.settings.loop_region,
 			data.settings.reverse,
 			data.sample_rate,
-			data.frames.len(),
+			Some(data.frames.len()),
 		);
 		let starting_frame_index = transport.position;
 		let position = starting_frame_index as f64 / data.sample_rate as f64;
@@ -208,12 +208,12 @@ impl Sound for StaticSound {
 				Command::SetPlaybackRegion(playback_region) => self.transport.set_playback_region(
 					playback_region,
 					self.data.sample_rate,
-					self.data.frames.len(),
+					Some(self.data.frames.len()),
 				),
 				Command::SetLoopRegion(loop_region) => self.transport.set_loop_region(
 					loop_region,
 					self.data.sample_rate,
-					self.data.frames.len(),
+					Some(self.data.frames.len()),
 				),
 				Command::Pause(tween) => self.pause(tween),
 				Command::Resume(tween) => self.resume(tween),

--- a/crates/kira/src/sound/streaming/data.rs
+++ b/crates/kira/src/sound/streaming/data.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::sound::SoundData;
 use ringbuf::HeapRb;
@@ -31,6 +32,13 @@ impl<Error: Send> StreamingSoundData<Error> {
 			decoder: Box::new(decoder),
 			settings,
 		}
+	}
+
+	/// Returns the duration of the audio.
+	pub fn duration(&self) -> Option<Duration> {
+		self.decoder.num_frames().map(|num_frames| {
+			Duration::from_secs_f64(num_frames as f64 / self.decoder.sample_rate() as f64)
+		})
 	}
 }
 

--- a/crates/kira/src/sound/streaming/decoder.rs
+++ b/crates/kira/src/sound/streaming/decoder.rs
@@ -12,7 +12,7 @@ pub trait Decoder: Send {
 	fn sample_rate(&self) -> u32;
 
 	/// Returns the total number of samples of audio.
-	fn num_frames(&self) -> usize;
+	fn num_frames(&self) -> Option<usize>;
 
 	/// Decodes the next chunk of audio.
 	fn decode(&mut self) -> Result<Vec<Frame>, Self::Error>;

--- a/crates/kira/src/sound/streaming/decoder/symphonia.rs
+++ b/crates/kira/src/sound/streaming/decoder/symphonia.rs
@@ -15,7 +15,7 @@ pub(crate) struct SymphoniaDecoder {
 	format_reader: Box<dyn FormatReader>,
 	decoder: Box<dyn Decoder>,
 	sample_rate: u32,
-	num_frames: usize,
+	num_frames: Option<usize>,
 	track_id: u32,
 }
 
@@ -42,9 +42,7 @@ impl SymphoniaDecoder {
 		let num_frames = default_track
 			.codec_params
 			.n_frames
-			.ok_or(FromFileError::UnknownSampleRate)?
-			.try_into()
-			.expect("could not convert u64 into usize");
+			.map(|frames| frames.try_into().expect("could not convert u64 into usize"));
 		let decoder = codecs.make(&default_track.codec_params, &Default::default())?;
 		let track_id = default_track.id;
 		Ok(Self {
@@ -64,7 +62,7 @@ impl super::Decoder for SymphoniaDecoder {
 		self.sample_rate
 	}
 
-	fn num_frames(&self) -> usize {
+	fn num_frames(&self) -> Option<usize> {
 		self.num_frames
 	}
 

--- a/crates/kira/src/sound/streaming/sound/decode_scheduler.rs
+++ b/crates/kira/src/sound/streaming/sound/decode_scheduler.rs
@@ -28,7 +28,7 @@ pub(crate) enum NextStep {
 pub(crate) struct DecodeScheduler<Error: Send + 'static> {
 	decoder: Box<dyn Decoder<Error = Error>>,
 	sample_rate: u32,
-	num_frames: usize,
+	num_frames: Option<usize>,
 	transport: Transport,
 	decoder_current_frame_index: usize,
 	decoded_chunk: Option<DecodedChunk>,

--- a/crates/kira/src/sound/streaming/sound/test.rs
+++ b/crates/kira/src/sound/streaming/sound/test.rs
@@ -41,8 +41,8 @@ impl Decoder for MockDecoder {
 		MOCK_DECODER_SAMPLE_RATE
 	}
 
-	fn num_frames(&self) -> usize {
-		self.frames.len()
+	fn num_frames(&self) -> Option<usize> {
+		Some(self.frames.len())
 	}
 
 	fn decode(&mut self) -> Result<Vec<Frame>, Self::Error> {

--- a/crates/kira/src/sound/transport/test.rs
+++ b/crates/kira/src/sound/transport/test.rs
@@ -1,10 +1,11 @@
+use crate::sound::{EndPosition, PlaybackPosition, Region};
 use super::Transport;
 
 #[test]
 fn stops_at_end() {
 	let mut transport = Transport {
 		position: 2,
-		playback_region: (2, 4),
+		playback_region: (2, Some(4)),
 		loop_region: None,
 		reverse: false,
 		playing: true,
@@ -22,7 +23,7 @@ fn stops_at_end() {
 fn stops_at_start_when_playing_backwards() {
 	let mut transport = Transport {
 		position: 2,
-		playback_region: (2, 4),
+		playback_region: (2, Some(4)),
 		loop_region: None,
 		reverse: false,
 		playing: true,
@@ -41,7 +42,7 @@ fn stops_at_start_when_playing_backwards() {
 fn loops() {
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: Some((2, 5)),
 		reverse: false,
 		playing: true,
@@ -62,7 +63,7 @@ fn loops() {
 fn loops_when_playing_backward() {
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: Some((2, 5)),
 		reverse: false,
 		playing: true,
@@ -84,7 +85,7 @@ fn loops_when_playing_backward() {
 fn loop_wrapping() {
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: Some((2, 5)),
 		reverse: false,
 		playing: true,
@@ -101,7 +102,7 @@ fn loop_wrapping() {
 fn seek_loop_wrapping() {
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: Some((2, 5)),
 		reverse: false,
 		playing: true,
@@ -116,7 +117,7 @@ fn seek_loop_wrapping() {
 fn seek_out_of_bounds() {
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: None,
 		reverse: false,
 		playing: true,
@@ -125,11 +126,56 @@ fn seek_out_of_bounds() {
 	assert!(!transport.playing);
 	let mut transport = Transport {
 		position: 0,
-		playback_region: (0, 10),
+		playback_region: (0, Some(10)),
 		loop_region: None,
 		reverse: false,
 		playing: true,
 	};
 	transport.seek_to(11);
 	assert!(!transport.playing);
+}
+
+#[test]
+fn seek_no_upper_bounds_without_playback_end() {
+	let mut transport = Transport {
+		position: 0,
+		playback_region: (0, None),
+		loop_region: None,
+		reverse: false,
+		playing: true,
+	};
+	transport.seek_to(-1);
+	assert!(!transport.playing);
+
+	let mut transport = Transport {
+		position: 0,
+		playback_region: (0, None),
+		loop_region: None,
+		reverse: false,
+		playing: true,
+	};
+	transport.seek_to(i64::MAX);
+	assert!(transport.playing);
+}
+
+#[test]
+fn prevents_playing_backwards_without_playback_end() {
+	std::panic::set_hook(Box::new(|_| {}));
+
+	let playback_region_end = Region {
+		start: PlaybackPosition::Samples(0),
+		end: EndPosition::EndOfAudio
+	};
+
+	assert!(std::panic::catch_unwind(|| Transport::new(playback_region_end, None,false, 0, None)).is_ok());
+	assert!(std::panic::catch_unwind(|| Transport::new(playback_region_end, None,true, 0, None)).is_err());
+
+	let playback_region_position = Region {
+		start: PlaybackPosition::Samples(0),
+		end: EndPosition::Custom(PlaybackPosition::Samples(10))
+	};
+
+	assert!(std::panic::catch_unwind(|| Transport::new(playback_region_position, None,true, 0, None)).is_ok());
+
+	let _hook = std::panic::take_hook();
 }


### PR DESCRIPTION
Fixes #67 

Hey there,

I tried to fix the issue I mentioned by making the num_frames an optional. It should be backward compatible and have no effect to existing solutions. In case there is no num_frames the playback end region is not known. This means the playing state can't be set to false as it is not known when the end is approached. 

Indeed I yet don't know how to test the case when num_frames could not be determined but the sound indeed has an end. As the transport doesn't know about the data size it can't handle the true end.
As well I have no idea what the impact of long running streams is. The data vector likely will just continuously be filled and never freed as long as the track is hold by the manager. Do you have insights here?

Feel free to give any feedback on that change :)

