### PR TITLE
Remove command delay

### DIFF
--- a/crates/kira/src/manager/backend/cpal.rs
+++ b/crates/kira/src/manager/backend/cpal.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "cpal")))]
 
 mod error;
+use std::num::NonZeroUsize;
+
 use cpal::{BufferSize, Device};
 pub use error::*;
 
@@ -18,6 +20,8 @@ pub struct CpalBackendSettings {
 	/// with the [`cpal::SupportedBufferSize`] range provided by the [`cpal::SupportedStreamConfig`]
 	/// API.
 	pub buffer_size: BufferSize,
+	/// The number of audio frames processed before the next pending command update.
+	pub process_command_interval: NonZeroUsize,
 }
 
 impl Default for CpalBackendSettings {
@@ -25,6 +29,7 @@ impl Default for CpalBackendSettings {
 		Self {
 			device: None,
 			buffer_size: BufferSize::Default,
+			process_command_interval: NonZeroUsize::new(1).unwrap(),
 		}
 	}
 }

--- a/crates/kira/src/manager/backend/cpal.rs
+++ b/crates/kira/src/manager/backend/cpal.rs
@@ -3,14 +3,30 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "cpal")))]
 
 mod error;
+use cpal::{BufferSize, Device};
 pub use error::*;
 
 /// Settings for the [`cpal`] backend.
-#[derive(Default)]
 pub struct CpalBackendSettings {
 	/// The output audio device to use. If [`None`], the default output
 	/// device will be used.
-	pub device: Option<cpal::Device>,
+	pub device: Option<Device>,
+	/// The buffer size used by the device. If it is set to [`BufferSize::Default`],
+	/// the default buffer size for the device will be used. Note that the default
+	/// buffer size might be surprisingly large, leading to latency issues. If
+	/// a lower latency is desired, consider using [`BufferSize::Fixed`] in accordance
+	/// with the [`cpal::SupportedBufferSize`] range provided by the [`cpal::SupportedStreamConfig`]
+	/// API.
+	pub buffer_size: BufferSize,
+}
+
+impl Default for CpalBackendSettings {
+	fn default() -> Self {
+		Self {
+			device: None,
+			buffer_size: BufferSize::Default,
+		}
+	}
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/kira/src/manager/backend/cpal/desktop.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop.rs
@@ -5,7 +5,7 @@ use stream_manager::{StreamManager, StreamManagerController};
 use crate::manager::backend::{Backend, Renderer};
 use cpal::{
 	traits::{DeviceTrait, HostTrait},
-	Device, StreamConfig,
+	BufferSize, Device, StreamConfig,
 };
 
 use super::{CpalBackendSettings, Error};
@@ -27,6 +27,7 @@ pub struct CpalBackend {
 	state: State,
 	/// Whether the device was specified by the user.
 	custom_device: bool,
+	buffer_size: BufferSize,
 }
 
 impl Backend for CpalBackend {
@@ -53,6 +54,7 @@ impl Backend for CpalBackend {
 			Self {
 				state: State::Uninitialized { device, config },
 				custom_device,
+				buffer_size: settings.buffer_size,
 			},
 			sample_rate,
 		))
@@ -67,6 +69,7 @@ impl Backend for CpalBackend {
 					device,
 					config,
 					self.custom_device,
+					self.buffer_size,
 				),
 			};
 		} else {

--- a/crates/kira/src/manager/backend/cpal/desktop.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop.rs
@@ -28,6 +28,8 @@ pub struct CpalBackend {
 	/// Whether the device was specified by the user.
 	custom_device: bool,
 	buffer_size: BufferSize,
+	/// The number of audio frames processed before the next pending command update.
+	process_command_interval: usize,
 }
 
 impl Backend for CpalBackend {
@@ -55,6 +57,7 @@ impl Backend for CpalBackend {
 				state: State::Uninitialized { device, config },
 				custom_device,
 				buffer_size: settings.buffer_size,
+				process_command_interval: settings.process_command_interval.get(),
 			},
 			sample_rate,
 		))
@@ -70,6 +73,7 @@ impl Backend for CpalBackend {
 					config,
 					self.custom_device,
 					self.buffer_size,
+					self.process_command_interval,
 				),
 			};
 		} else {

--- a/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::manager::backend::Renderer;
 use cpal::{
 	traits::{DeviceTrait, HostTrait, StreamTrait},
-	Device, Stream, StreamConfig, StreamError,
+	BufferSize, Device, Stream, StreamConfig, StreamError,
 };
 use ringbuf::{HeapConsumer, HeapRb};
 
@@ -51,14 +51,16 @@ pub(super) struct StreamManager {
 	device_name: String,
 	sample_rate: u32,
 	custom_device: bool,
+	buffer_size: BufferSize,
 }
 
 impl StreamManager {
 	pub fn start(
 		renderer: Renderer,
 		device: Device,
-		config: StreamConfig,
+		mut config: StreamConfig,
 		custom_device: bool,
+		buffer_size: BufferSize,
 	) -> StreamManagerController {
 		let should_drop = Arc::new(AtomicBool::new(false));
 		let should_drop_clone = should_drop.clone();
@@ -68,8 +70,9 @@ impl StreamManager {
 				device_name: device_name(&device),
 				sample_rate: config.sample_rate.0,
 				custom_device,
+				buffer_size,
 			};
-			stream_manager.start_stream(&device, &config).unwrap();
+			stream_manager.start_stream(&device, &mut config).unwrap();
 			loop {
 				std::thread::sleep(CHECK_STREAM_INTERVAL);
 				if should_drop.load(Ordering::SeqCst) {
@@ -93,9 +96,9 @@ impl StreamManager {
 			// check for device disconnection
 			if let Some(StreamError::DeviceNotAvailable) = stream_error_consumer.pop() {
 				self.stop_stream();
-				if let Ok((device, config)) = default_device_and_config() {
+				if let Ok((device, mut config)) = default_device_and_config() {
 					// TODO: gracefully handle errors that occur in this function
-					self.start_stream(&device, &config).unwrap();
+					self.start_stream(&device, &mut config).unwrap();
 				}
 			}
 			// check for device changes if a custom device hasn't been specified
@@ -104,25 +107,26 @@ impl StreamManager {
 			// see: https://github.com/tesselode/kira/issues/38
 			#[cfg(not(target_os = "macos"))]
 			if !self.custom_device {
-				if let Ok((device, config)) = default_device_and_config() {
+				if let Ok((device, mut config)) = default_device_and_config() {
 					let device_name = device_name(&device);
 					let sample_rate = config.sample_rate.0;
 					if device_name != self.device_name || sample_rate != self.sample_rate {
 						self.stop_stream();
-						self.start_stream(&device, &config).unwrap();
+						self.start_stream(&device, &mut config).unwrap();
 					}
 				}
 			}
 		}
 	}
 
-	fn start_stream(&mut self, device: &Device, config: &StreamConfig) -> Result<(), Error> {
+	fn start_stream(&mut self, device: &Device, config: &mut StreamConfig) -> Result<(), Error> {
 		let mut renderer =
 			if let State::Idle { renderer } = std::mem::replace(&mut self.state, State::Empty) {
 				renderer
 			} else {
 				panic!("trying to start a stream when the stream manager is not idle");
 			};
+		config.buffer_size = self.buffer_size; // this won't change anything if the buffer size is BufferSize::Default
 		let device_name = device_name(device);
 		let sample_rate = config.sample_rate.0;
 		if sample_rate != self.sample_rate {

--- a/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
+++ b/crates/kira/src/manager/backend/cpal/desktop/stream_manager.rs
@@ -134,8 +134,7 @@ impl StreamManager {
 		}
 		self.device_name = device_name;
 		self.sample_rate = sample_rate;
-		let (renderer_wrapper, renderer_consumer) = RendererWrapper::new(renderer);
-		let mut renderer_wrapper = renderer_wrapper;
+		let (mut renderer_wrapper, renderer_consumer) = RendererWrapper::new(renderer);
 
 		let (mut stream_error_producer, stream_error_consumer) = HeapRb::new(1).split();
 		let channels = config.channels;

--- a/crates/kira/src/manager/backend/cpal/wasm.rs
+++ b/crates/kira/src/manager/backend/cpal/wasm.rs
@@ -28,7 +28,7 @@ impl Backend for CpalBackend {
 
 	type Error = Error;
 
-	fn setup(_settings: Self::Settings) -> Result<(Self, u32), Self::Error> {
+	fn setup(settings: Self::Settings) -> Result<(Self, u32), Self::Error> {
 		let host = cpal::default_host();
 		let device = if let Some(device) = settings.device {
 			device


### PR DESCRIPTION
Fixes command delay by processing pending commands for each audio frame. Fixes https://github.com/tesselode/kira/issues/65 (and includes https://github.com/tesselode/kira/pull/69)
This will fix issues such as volume commands not applying immediately and will remove the delay between the `stream.play()` call and the actual sound being played.

This shouldn't add much overhead (I haven't benchmarked it though). You can pass the `process_command_interval` option to set the amount of audio frames between `on_start_processing` calls. Currently set to 1 (NonZeroUsize), but it might be better to increase that value (needs benchmarking).