### PR TITLE
Expose duration related methods

### DIFF
--- a/crates/kira/src/sound.rs
+++ b/crates/kira/src/sound.rs
@@ -126,6 +126,22 @@ pub struct Region {
 	pub end: EndPosition,
 }
 
+impl Region {
+	/// Given the number of frames and a sample rate, returns audio region duration.
+	pub fn duration(&self, num_frames: usize, sample_rate: u32) -> std::time::Duration {
+		let (start, end) = self.into_samples(num_frames, sample_rate);
+		std::time::Duration::from_secs_f64((end - start) as f64 / sample_rate as f64)
+	}
+	pub(crate) fn into_samples(&self, num_frames: usize, sample_rate: u32) -> (usize, usize) {
+		let start = self.start.into_samples(sample_rate);
+		let end = match self.end {
+			EndPosition::EndOfAudio => num_frames,
+			EndPosition::Custom(end) => end.into_samples(sample_rate),
+		};
+		(start, end)
+	}
+}
+
 impl<T: Into<PlaybackPosition>> From<RangeFrom<T>> for Region {
 	fn from(range: RangeFrom<T>) -> Self {
 		Self {

--- a/crates/kira/src/sound/playback_position.rs
+++ b/crates/kira/src/sound/playback_position.rs
@@ -12,8 +12,10 @@ pub enum PlaybackPosition {
 }
 
 impl PlaybackPosition {
+	/// Given a sample rate,
+	/// consumes this [PlaybackPosition] and returns its [samples][PlaybackPosition::Samples].
 	#[must_use]
-	pub(crate) fn into_samples(self, sample_rate: u32) -> usize {
+	pub fn into_samples(self, sample_rate: u32) -> usize {
 		match self {
 			PlaybackPosition::Seconds(seconds) => (seconds * sample_rate as f64).round() as usize,
 			PlaybackPosition::Samples(samples) => samples,

--- a/crates/kira/src/sound/static_sound/data.rs
+++ b/crates/kira/src/sound/static_sound/data.rs
@@ -447,7 +447,8 @@ impl Debug for FramesDebug {
 	}
 }
 
-pub(crate) fn num_frames(frames: &[Frame], slice: Option<(usize, usize)>) -> usize {
+/// Given a slice of [Frame] and [Region], returns the number of frames.
+pub fn num_frames(frames: &[Frame], slice: Option<(usize, usize)>) -> usize {
 	if let Some((start, end)) = slice {
 		end - start
 	} else {

--- a/crates/kira/src/sound/static_sound/data.rs
+++ b/crates/kira/src/sound/static_sound/data.rs
@@ -12,9 +12,7 @@ use std::{
 
 use crate::{
 	frame::Frame,
-	sound::{
-		EndPosition, IntoOptionalRegion, PlaybackPosition, PlaybackRate, Region, Sound, SoundData,
-	},
+	sound::{IntoOptionalRegion, PlaybackPosition, PlaybackRate, Sound, SoundData},
 	tween::{Tween, Value},
 	OutputDestination, StartTime, Volume,
 };
@@ -385,14 +383,9 @@ impl StaticSoundData {
 	#[must_use = "This method returns a modified StaticSoundData and does not mutate the original value"]
 	pub fn slice(&self, region: impl IntoOptionalRegion) -> Self {
 		let mut new = self.clone();
-		new.slice = region.into_optional_region().map(|Region { start, end }| {
-			let start = start.into_samples(self.sample_rate);
-			let end = match end {
-				EndPosition::EndOfAudio => self.frames.len(),
-				EndPosition::Custom(end) => end.into_samples(self.sample_rate),
-			};
-			(start, end)
-		});
+		new.slice = region
+			.into_optional_region()
+			.map(|region| region.into_samples(self.frames.len(), self.sample_rate));
 		new
 	}
 

--- a/crates/kira/src/sound/static_sound/data.rs
+++ b/crates/kira/src/sound/static_sound/data.rs
@@ -408,6 +408,11 @@ impl StaticSoundData {
 			},
 		)
 	}
+
+	/// Returns the sample rate of the audio.
+	pub fn sample_rate(&self) -> u32 {
+		self.sample_rate
+	}
 }
 
 impl SoundData for StaticSoundData {

--- a/crates/kira/src/sound/streaming/data.rs
+++ b/crates/kira/src/sound/streaming/data.rs
@@ -3,9 +3,7 @@ mod test;
 
 use std::{sync::Arc, time::Duration};
 
-use crate::sound::{
-	EndPosition, IntoOptionalRegion, PlaybackPosition, PlaybackRate, Region, SoundData,
-};
+use crate::sound::{IntoOptionalRegion, PlaybackPosition, PlaybackRate, SoundData};
 use crate::tween::{Tween, Value};
 use crate::{OutputDestination, StartTime, Volume};
 use ringbuf::HeapRb;
@@ -325,13 +323,8 @@ impl<Error: Send> StreamingSoundData<Error> {
 	*/
 	#[must_use = "This method consumes self and returns a modified StreamingSoundData, so the return value should be used"]
 	pub fn slice(mut self, region: impl IntoOptionalRegion) -> Self {
-		self.slice = region.into_optional_region().map(|Region { start, end }| {
-			let start = start.into_samples(self.decoder.sample_rate());
-			let end = match end {
-				EndPosition::EndOfAudio => self.decoder.num_frames(),
-				EndPosition::Custom(end) => end.into_samples(self.decoder.sample_rate()),
-			};
-			(start, end)
+		self.slice = region.into_optional_region().map(|region| {
+			region.into_samples(self.decoder.num_frames(), self.decoder.sample_rate())
 		});
 		self
 	}

--- a/crates/kira/src/sound/streaming/data.rs
+++ b/crates/kira/src/sound/streaming/data.rs
@@ -333,6 +333,11 @@ impl<Error: Send> StreamingSoundData<Error> {
 	pub fn sample_rate(&self) -> u32 {
 		self.decoder.sample_rate()
 	}
+
+	/// Returns the number of frames from the decoder.
+	pub fn decoder_num_frames(&self) -> usize {
+		self.decoder.num_frames()
+	}
 }
 
 impl<T: Send> StreamingSoundData<T> {}

--- a/crates/kira/src/sound/streaming/data.rs
+++ b/crates/kira/src/sound/streaming/data.rs
@@ -335,6 +335,11 @@ impl<Error: Send> StreamingSoundData<Error> {
 		});
 		self
 	}
+
+	/// Returns the sample rate from the decoder.
+	pub fn sample_rate(&self) -> u32 {
+		self.decoder.sample_rate()
+	}
 }
 
 impl<T: Send> StreamingSoundData<T> {}

--- a/crates/kira/src/sound/transport.rs
+++ b/crates/kira/src/sound/transport.rs
@@ -1,4 +1,4 @@
-use super::{EndPosition, Region};
+use super::Region;
 
 #[cfg(test)]
 mod test;
@@ -20,14 +20,8 @@ impl Transport {
 		sample_rate: u32,
 		num_frames: usize,
 	) -> Self {
-		let loop_region = loop_region.map(|loop_region| {
-			let loop_start = loop_region.start.into_samples(sample_rate);
-			let loop_end = match loop_region.end {
-				EndPosition::EndOfAudio => num_frames,
-				EndPosition::Custom(end_position) => end_position.into_samples(sample_rate),
-			};
-			(loop_start, loop_end)
-		});
+		let loop_region =
+			loop_region.map(|loop_region| loop_region.into_samples(num_frames, sample_rate));
 		Self {
 			position: if reverse {
 				num_frames - 1 - start_position
@@ -45,14 +39,8 @@ impl Transport {
 		sample_rate: u32,
 		num_frames: usize,
 	) {
-		self.loop_region = loop_region.map(|loop_region| {
-			let loop_start = loop_region.start.into_samples(sample_rate);
-			let loop_end = match loop_region.end {
-				EndPosition::EndOfAudio => num_frames,
-				EndPosition::Custom(end_position) => end_position.into_samples(sample_rate),
-			};
-			(loop_start, loop_end)
-		});
+		self.loop_region =
+			loop_region.map(|loop_region| loop_region.into_samples(num_frames, sample_rate));
 	}
 
 	pub fn increment_position(&mut self, num_frames: usize) {


### PR DESCRIPTION
This PR does not address #102, but at least it exposes methods required to allow downstream users to calculate duration, including for `Region`, on their own.