### PR TITLE
Fix reference invalidation under stacked borrows in `arena::iter::IterMut`

### DIFF
--- a/crates/kira/src/arena/iter.rs
+++ b/crates/kira/src/arena/iter.rs
@@ -81,7 +81,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 	fn next(&mut self) -> Option<Self::Item> {
 		if let Some(index) = self.next_occupied_slot_index {
 			let index_usize = usize::from(index);
-			// Since next_occupied_slot_index isn't always increasing/increasing there aren't any
+			// Since next_occupied_slot_index isn't always increasing/decreasing there aren't any
 			// easy safe ways to iterate following this order.
 			let slot = if index_usize < self.slots.len() {
 				// as_mut_ptr and get_unchecked_mut on *mut [T] are unstable :(

--- a/crates/kira/src/arena/iter.rs
+++ b/crates/kira/src/arena/iter.rs
@@ -1,6 +1,10 @@
 //! [`Arena`] iterators.
 
-use crate::arena::{slot::ArenaSlotState, Arena, Key};
+use crate::arena::{
+	slot::{ArenaSlot, ArenaSlotState},
+	Arena, Key,
+};
+use core::marker::PhantomData;
 
 /// Iterates over shared references to the items in
 /// the [`Arena`].
@@ -56,7 +60,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
 /// The most recently added items will be visited first.
 pub struct IterMut<'a, T> {
 	next_occupied_slot_index: Option<u16>,
-	arena: &'a mut Arena<T>,
+	slots: *mut [ArenaSlot<T>],
+	marker: PhantomData<&'a mut Arena<T>>,
 }
 
 impl<'a, T> IterMut<'a, T> {
@@ -64,7 +69,8 @@ impl<'a, T> IterMut<'a, T> {
 	pub(super) fn new(arena: &'a mut Arena<T>) -> Self {
 		Self {
 			next_occupied_slot_index: arena.first_occupied_slot_index,
-			arena,
+			slots: arena.slots.as_mut_slice(),
+			marker: PhantomData,
 		}
 	}
 }
@@ -74,7 +80,23 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
 	fn next(&mut self) -> Option<Self::Item> {
 		if let Some(index) = self.next_occupied_slot_index {
-			let slot = &mut self.arena.slots[index as usize];
+			let index_usize = usize::from(index);
+			// Since next_occupied_slot_index isn't always increasing/increasing there aren't any
+			// easy safe ways to iterate following this order.
+			let slot = if index_usize < self.slots.len() {
+				// as_mut_ptr and get_unchecked_mut on *mut [T] are unstable :(
+				let start_ptr = self.slots.cast::<ArenaSlot<T>>();
+				// SAFETY: We checked that this is in bounds.
+				let slot_ptr = unsafe { start_ptr.add(index_usize) };
+				// SAFETY:
+				// * This relies on the invariant that `next_occupied_slot_index` never repeats. If
+				//   it did repeat, we could create aliasing mutable references here.
+				// * Lifetime is the same that we mutably borrow the Arena for.
+				unsafe { slot_ptr.as_mut::<'a>() }.unwrap()
+			} else {
+				unreachable!("next_occupied_slot_index should always point to valid slot");
+			};
+
 			if let ArenaSlotState::Occupied {
 				data,
 				next_occupied_slot_index,
@@ -87,13 +109,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 						index,
 						generation: slot.generation,
 					},
-					// using a small bit of unsafe code here to get around
-					// borrow checker limitations. this workaround is stolen
-					// from slotmap: https://github.com/orlp/slotmap/blob/master/src/hop.rs#L1165
-					unsafe {
-						let data: *mut T = &mut *data;
-						&mut *data
-					},
+					data,
 				))
 			} else {
 				panic!("the iterator should not encounter a free slot");

--- a/crates/kira/src/arena/slot.rs
+++ b/crates/kira/src/arena/slot.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ArenaSlotState<T> {
+pub(super) enum ArenaSlotState<T> {
 	Free,
 	Occupied {
 		data: T,
@@ -9,21 +9,21 @@ pub(crate) enum ArenaSlotState<T> {
 }
 
 #[derive(Debug)]
-pub(crate) struct ArenaSlot<T> {
-	pub(crate) state: ArenaSlotState<T>,
-	pub(crate) generation: u32,
+pub(super) struct ArenaSlot<T> {
+	pub(super) state: ArenaSlotState<T>,
+	pub(super) generation: u32,
 }
 
 impl<T> ArenaSlot<T> {
 	#[must_use]
-	pub(crate) fn new() -> Self {
+	pub(super) fn new() -> Self {
 		Self {
 			state: ArenaSlotState::Free,
 			generation: 0,
 		}
 	}
 
-	pub(crate) fn set_previous_occupied_slot_index(&mut self, index: Option<u16>) {
+	pub(super) fn set_previous_occupied_slot_index(&mut self, index: Option<u16>) {
 		if let ArenaSlotState::Occupied {
 			previous_occupied_slot_index,
 			..
@@ -35,7 +35,7 @@ impl<T> ArenaSlot<T> {
 		}
 	}
 
-	pub(crate) fn set_next_occupied_slot_index(&mut self, index: Option<u16>) {
+	pub(super) fn set_next_occupied_slot_index(&mut self, index: Option<u16>) {
 		if let ArenaSlotState::Occupied {
 			next_occupied_slot_index,
 			..

--- a/crates/kira/src/arena/test.rs
+++ b/crates/kira/src/arena/test.rs
@@ -265,6 +265,19 @@ fn iter_mut() {
 	assert_eq!(iter.next(), None);
 }
 
+// Useful for using miri to test unsafe code in the mutable iteration implementation.
+#[test]
+fn iter_mut_use_after_next() {
+	let mut arena = Arena::new(2);
+	let _ = arena.insert(1).unwrap();
+	let _ = arena.insert(2).unwrap();
+	let mut iter = arena.iter_mut();
+	let first = iter.next().unwrap();
+	let _second = iter.next().unwrap();
+	// Let miri detect if `first` was invalidated by trying to use it.
+	*first.1 = 3;
+}
+
 #[test]
 fn drain_filter() {
 	let mut arena = Arena::new(6);


### PR DESCRIPTION
Hi! I was exploring the one unsafe line in this crate and found a small aspect to fix.

I added this test:
```rs
fn iter_mut_use_after_next() {
	let mut arena = Arena::new(2);
	let _ = arena.insert(1).unwrap();
	let _ = arena.insert(2).unwrap();
	let mut iter = arena.iter_mut();
	let first = iter.next().unwrap();
	let _second = iter.next().unwrap();
	*first.1 = 3;
}
```
Running with miri `cargo +nightly miri test iter_mut_use_after_next` shows:
```
test arena::test::iter_mut_use_after_next ... error: Undefined Behavior: attempting a write access using <512353> at alloc206762[0x18], but that tag does not exist in the borrow stack for this location
   --> crates/kira/src/arena/test.rs:278:2
    |
278 |     *first.1 = 3;
    |     ^^^^^^^^^^^^
    |     |
    |     attempting a write access using <512353> at alloc206762[0x18], but that tag does not exist in the borrow stack for this location
    |     this error occurs as part of an access at alloc206762[0x18..0x1c]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <512353> was created by a Unique retag at offsets [0x18..0x1c]
   --> crates/kira/src/arena/test.rs:275:14
    |
275 |     let first = iter.next().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^
help: <512353> was later invalidated at offsets [0x0..0x30] by a Unique retag
   --> crates/kira/src/arena/iter.rs:77:36
    |
77  |             let slot = &mut self.arena.slots[index as usize];
    |                                             ^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span) on thread `arena::test::it`:
    = note: inside `arena::test::iter_mut_use_after_next` at crates/kira/src/arena/test.rs:278:2: 278:14
```
Notably things are fine with tree borrows `MIRIFLAGS="-Zmiri-tree-borrows" cargo +nightly miri test iter_mut_use_after_next`:
```
test arena::test::iter_mut_use_after_next ... ok
```
However, it is preferable to make things work with both models since the final model will likely be some mixture of these two.

The issue in stacked borrows is that creating the mutable reference to the slice (inside Vec's index impl) essentially asserts that it has unique access to the whole contents of the slice which invalidates any previously derived references.

We can avoid this by getting a raw pointer when creating the `IterMut` and exclusively using that pointer to derive references to the individual items. Raw pointer ergonomics aren't the best, but at least not having a reference to the `Vec` also makes it more difficult to accidentally introduce other code that uses the `Vec` in ways that would invalidate the references.