### PR TITLE
Remove loops from `impl Add/Sub<f64> for ClockTime`

### DIFF
--- a/crates/kira/src/clock/time/test.rs
+++ b/crates/kira/src/clock/time/test.rs
@@ -108,6 +108,14 @@ fn add_f64() {
 	} + 3.5;
 	assert_eq!(time.ticks, 6);
 	assert_relative_eq!(time.fraction, 0.0);
+	let id = fake_clock_id();
+	let time = ClockTime {
+		clock: id,
+		ticks: 5,
+		fraction: 0.5,
+	} + (-3.7);
+	assert_eq!(time.ticks, 1);
+	assert_relative_eq!(time.fraction, 0.8);
 }
 
 #[test]
@@ -127,6 +135,14 @@ fn sub_f64() {
 	} - 3.5;
 	assert_eq!(time.ticks, 2);
 	assert_relative_eq!(time.fraction, 0.0);
+	let id = fake_clock_id();
+	let time = ClockTime {
+		clock: id,
+		ticks: 2,
+		fraction: 0.5,
+	} - (-3.7);
+	assert_eq!(time.ticks, 6);
+	assert_relative_eq!(time.fraction, 0.2);
 }
 
 #[test]


### PR DESCRIPTION
This caused problems at [veloren](https://gitlab.com/veloren/veloren) where another bug would cause a very large number to be added to a `ClockTime` and caused the entire game to freeze.

The new implementation will still misbehave if non-finite numbers are added/removed, therefore the `debug_assert!` checks.