### PR TITLE
decode default audio track when multiple tracks are present

### DIFF
--- a/crates/kira/src/sound/streaming/decoder/symphonia.rs
+++ b/crates/kira/src/sound/streaming/decoder/symphonia.rs
@@ -69,7 +69,12 @@ impl super::Decoder for SymphoniaDecoder {
 	}
 
 	fn decode(&mut self) -> Result<Vec<Frame>, Self::Error> {
-		let packet = self.format_reader.next_packet()?;
+		let packet = loop {
+			let packet = self.format_reader.next_packet()?;
+			if self.track_id == packet.track_id() {
+				break packet;
+			}
+		};
 		let buffer = self.decoder.decode(&packet)?;
 		load_frames_from_buffer_ref(&buffer)
 	}


### PR DESCRIPTION
Fixes issue failing to play `m4a` tracks containing subtitle track/stream as well.