### PR TITLE
Fix failed to resolve 'paste' crate & migrate to pastey

### DIFF
--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -15,7 +15,7 @@ assert_no_alloc = { version = "1.1.2", optional = true }
 atomic-arena = "0.1.1"
 glam = { version = "0.30.0", features = ["mint"] }
 mint = "0.5.9"
-paste = { package="pastey", version = "*"}
+pastey = "0.1.1"
 rtrb = "0.3.1"
 serde = { version = "1.0.164", features = ["derive"], optional = true }
 symphonia = { version = "0.5.0", optional = true, default-features = false }

--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -15,7 +15,7 @@ assert_no_alloc = { version = "1.1.2", optional = true }
 atomic-arena = "0.1.1"
 glam = { version = "0.30.0", features = ["mint"] }
 mint = "0.5.9"
-paste = "1.0.14"
+paste = { package="pastey", version = "*"}
 rtrb = "0.3.1"
 serde = { version = "1.0.164", features = ["derive"], optional = true }
 symphonia = { version = "0.5.0", optional = true, default-features = false }

--- a/crates/kira/src/backend/resources.rs
+++ b/crates/kira/src/backend/resources.rs
@@ -70,12 +70,12 @@ impl<T> ResourceStorage<T> {
 	}
 
 	#[must_use]
-	pub fn iter(&self) -> atomic_arena::iter::Iter<T> {
+	pub fn iter(&self) -> atomic_arena::iter::Iter<'_, T> {
 		self.resources.iter()
 	}
 
 	#[must_use]
-	pub fn iter_mut(&mut self) -> atomic_arena::iter::IterMut<T> {
+	pub fn iter_mut(&mut self) -> atomic_arena::iter::IterMut<'_, T> {
 		self.resources.iter_mut()
 	}
 
@@ -145,7 +145,7 @@ impl<T> SelfReferentialResourceStorage<T> {
 	}
 
 	#[must_use]
-	pub fn iter_mut(&mut self) -> atomic_arena::iter::IterMut<T> {
+	pub fn iter_mut(&mut self) -> atomic_arena::iter::IterMut<'_, T> {
 		self.resources.iter_mut()
 	}
 

--- a/crates/kira/src/command.rs
+++ b/crates/kira/src/command.rs
@@ -138,7 +138,7 @@ macro_rules! command_writers_and_readers {
 
 		#[must_use]
 		pub(crate) fn command_writers_and_readers() -> (CommandWriters, CommandReaders) {
-			paste::paste! {
+			$crate::paste::paste! {
 				$(let ([<$field_name _writer>], [<$field_name _reader>]) = $crate::command::command_writer_and_reader();)*
 				let command_writers = CommandWriters {
 					$($field_name: [<$field_name _writer>]),*
@@ -154,7 +154,7 @@ macro_rules! command_writers_and_readers {
 
 macro_rules! read_commands_into_parameters {
 	($self:ident, $($parameter_name:ident),*$(,)?) => {
-		paste::paste! {
+		$crate::paste::paste! {
 			$($self.$parameter_name.read_command(&mut $self.command_readers.[<set_ $parameter_name>]);)*
 		}
 	};
@@ -162,7 +162,7 @@ macro_rules! read_commands_into_parameters {
 
 macro_rules! handle_param_setters {
 	($($(#[$m:meta])* $name:ident: $type:ty),*$(,)?) => {
-		paste::paste! {
+		$crate::paste::paste! {
 			$(
 				$(#[$m])*
 				pub fn [<set_ $name>](&mut self, $name: impl Into<$crate::Value<$type>>, tween: $crate::tween::Tween) {

--- a/crates/kira/src/command.rs
+++ b/crates/kira/src/command.rs
@@ -138,7 +138,7 @@ macro_rules! command_writers_and_readers {
 
 		#[must_use]
 		pub(crate) fn command_writers_and_readers() -> (CommandWriters, CommandReaders) {
-			$crate::paste::paste! {
+			$crate::pastey::paste! {
 				$(let ([<$field_name _writer>], [<$field_name _reader>]) = $crate::command::command_writer_and_reader();)*
 				let command_writers = CommandWriters {
 					$($field_name: [<$field_name _writer>]),*
@@ -154,7 +154,7 @@ macro_rules! command_writers_and_readers {
 
 macro_rules! read_commands_into_parameters {
 	($self:ident, $($parameter_name:ident),*$(,)?) => {
-		$crate::paste::paste! {
+		$crate::pastey::paste! {
 			$($self.$parameter_name.read_command(&mut $self.command_readers.[<set_ $parameter_name>]);)*
 		}
 	};
@@ -162,7 +162,7 @@ macro_rules! read_commands_into_parameters {
 
 macro_rules! handle_param_setters {
 	($($(#[$m:meta])* $name:ident: $type:ty),*$(,)?) => {
-		$crate::paste::paste! {
+		$crate::pastey::paste! {
 			$(
 				$(#[$m])*
 				pub fn [<set_ $name>](&mut self, $name: impl Into<$crate::Value<$type>>, tween: $crate::tween::Tween) {

--- a/crates/kira/src/lib.rs
+++ b/crates/kira/src/lib.rs
@@ -126,13 +126,13 @@ The Kira crate has the following feature flags:
 - `symphonia` (enabled by default) - allows loading and streaming audio from common
   audio formats, like MP3 and WAV.
 	- `mp3` (enabled by default) - enables support for loading and streaming MP3 audio (enables
-	  the `symphonia` feature automatically)
+	    the `symphonia` feature automatically)
 	- `ogg` (enabled by default) - enables support for loading and streaming OGG audio (enables
-	  the `symphonia` feature automatically)
+	    the `symphonia` feature automatically)
 	- `flac` (enabled by default) - enables support for loading and streaming FLAC audio (enables
-	  the `symphonia` feature automatically)
+	    the `symphonia` feature automatically)
 	- `wav` (enabled by default) - enables support for loading and streaming WAV audio (enables
-	  the `symphonia` feature automatically)
+	    the `symphonia` feature automatically)
 - `serde` - adds `Serialize` and `Deserialize` implementations for the following types:
 	- [`Capacities`]
 	- [`ClockSpeed`](crate::clock::ClockSpeed)

--- a/crates/kira/src/lib.rs
+++ b/crates/kira/src/lib.rs
@@ -270,3 +270,4 @@ pub use semitones::*;
 pub use start_time::*;
 pub use tween::*;
 pub use value::*;
+pub use ::paste;

--- a/crates/kira/src/lib.rs
+++ b/crates/kira/src/lib.rs
@@ -270,4 +270,4 @@ pub use semitones::*;
 pub use start_time::*;
 pub use tween::*;
 pub use value::*;
-pub use ::paste;
+pub use pastey;


### PR DESCRIPTION
Using `command_writers_and_readers!` macro outside of kira causes `failed to resolve: use of undeclared crate or module paste` error.  

`command_writers_and_readers!` macro generates code that uses paste::paste! macro. But, paste is not always included in external crate's dependencies. That cause `Failed to resolve` error.

You can solve this problem by adding "paste" in external crate dependencies. But adding crate not used directly is little strange.

This PR solve this problem by extern paste crate by `pub use ::paste` in lib.rs and use paste package via $crate metavar.

I found similar issue in paste crate repository.  
https://github.com/dtolnay/paste/issues/69

Also, there is the post describes about solution.
https://users.rust-lang.org/t/proc-macros-using-third-party-crate/42465/4