### PR TITLE
Target both cpal 0.15 and 0.16

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# v0.10.9 - Unreleased
+
+- Target both cpal v0.15 and v0.16
+
 # v0.10.8 - June 17, 2025
 
 - Decode default audio track when multiple tracks are present (thanks @siavashserver!)

--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kira"
-version = "0.10.8"
+version = "0.10.9"
 authors = ["Andrew Minnich <aminnich3@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -22,11 +22,11 @@ symphonia = { version = "0.5.0", optional = true, default-features = false }
 triple_buffer = "8.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.cpal]
-version = "0.15.1"
+version = ">=0.15, <=0.16"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.cpal]
-version = "0.15.1"
+version = ">=0.15, <=0.16"
 optional = true
 features = ["wasm-bindgen"]
 


### PR DESCRIPTION
Both versions are compatible with the current Kira code. This could be released as a patch version, since it's fully backward compatible.