### PR TITLE
Use portable-atomic on platforms without u64 atomics

### DIFF
--- a/crates/kira/Cargo.toml
+++ b/crates/kira/Cargo.toml
@@ -33,6 +33,9 @@ features = ["wasm-bindgen"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 send_wrapper = "0.6.0"
 
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = "1"
+
 [features]
 default = ["cpal", "mp3", "ogg", "flac", "wav"]
 mp3 = ["symphonia", "symphonia/mp3"]

--- a/crates/kira/src/backend/cpal/desktop/stream_manager.rs
+++ b/crates/kira/src/backend/cpal/desktop/stream_manager.rs
@@ -3,10 +3,15 @@ mod send_on_drop;
 use std::{
 	sync::{
 		Arc, Mutex,
-		atomic::{AtomicBool, AtomicU64, Ordering},
+		atomic::{AtomicBool, Ordering},
 	},
 	time::Duration,
 };
+
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 use super::renderer_with_cpu_usage::RendererWithCpuUsage;
 use cpal::{

--- a/crates/kira/src/clock.rs
+++ b/crates/kira/src/clock.rs
@@ -149,8 +149,13 @@ pub use time::*;
 
 use std::sync::{
 	Arc,
-	atomic::{AtomicBool, AtomicU64, Ordering},
+	atomic::{AtomicBool, Ordering},
 };
+
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 use crate::{
 	Parameter, Value,

--- a/crates/kira/src/sound/static_sound/sound.rs
+++ b/crates/kira/src/sound/static_sound/sound.rs
@@ -5,8 +5,13 @@ mod test;
 
 use std::sync::{
 	Arc,
-	atomic::{AtomicU8, AtomicU64, Ordering},
+	atomic::{AtomicU8, Ordering},
 };
+
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 use crate::{
 	Decibels, Panning, Parameter, PlaybackRate, StartTime, Tween,

--- a/crates/kira/src/sound/streaming/sound.rs
+++ b/crates/kira/src/sound/streaming/sound.rs
@@ -5,8 +5,13 @@ mod test;
 
 use std::sync::{
 	Arc,
-	atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
+	atomic::{AtomicBool, AtomicU8, Ordering},
 };
+
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 use crate::{
 	Decibels, Panning, Parameter, PlaybackRate, StartTime, Tween,


### PR DESCRIPTION
This has been tested on `powerpc-unknown-linux-gnu`, which supports atomics only up to `u32`.  Without this commit, building kira would fail with:
```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> crates/kira/src/backend/cpal/desktop/stream_manager.rs:6:24
  |
6 |         atomic::{AtomicBool, AtomicU64, Ordering},
  |                              ^^^^^^^^^
  |                              |
  |                              no `AtomicU64` in `sync::atomic`
  |                              help: a similar name exists in the module: `AtomicU32`
```

Edit: This also depends on https://github.com/not-fl3/quad-rand/pull/23 in order to make the whole testsuite pass, but can be merged independently.